### PR TITLE
cancel to pre-install playground and cluster after installing the tiup

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -354,7 +354,7 @@ async function checkEnvs() {
     )
     if (res === 'Install') {
       await tiup.invokeAnyInNewTerminal(
-        `curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh && tiup install cluster && tiup install playground && exit`,
+        `curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh && exit`,
         'install tiup'
       )
     }


### PR DESCRIPTION
Related: https://github.com/tidb-incubator/tide/issues/33#issuecomment-780586873

Because it will fail if it is the real first-time installation for tiup, and some people may don't need playground or cluster components before they use it.