### PR TITLE
Use `--comments` when calling MySQL Client to avoid stripping of TiDB comments

### DIFF
--- a/src/cluster/command.ts
+++ b/src/cluster/command.ts
@@ -579,7 +579,7 @@ export class ClusterCommand {
     }
     const { id } = availableInst
     const [host, port] = id.split(':')
-    const cmd = `mysql --host ${host} --port ${port} -u root -p`
+    const cmd = `mysql --host ${host} --port ${port} -u root -p --comments`
     await tiup.invokeAnyInNewTerminal(cmd, `mysql ${id}`)
   }
 

--- a/src/playground/command.ts
+++ b/src/playground/command.ts
@@ -249,7 +249,7 @@ export class PlaygroundCommand {
   }
 
   static async connectMySQL(tiup: TiUP) {
-    const cmd = `mysql --host 127.0.0.1 --port 4000 -u root -p`
+    const cmd = `mysql --host 127.0.0.1 --port 4000 -u root -p --comments`
     tiup.invokeAnyInNewTerminal(cmd, 'connect tidb')
   }
 


### PR DESCRIPTION
Without this this happens:
```
mysql> SELECT /*T 'ti', */ 'db';
+----+
| db |
+----+
| db |
+----+
1 row in set (0.00 sec)
```

The `/*T ... */` syntax is use in the output of `SHOW CREATE TABLE...`
and other locations.